### PR TITLE
Update firestore.rules

### DIFF
--- a/config/firebase/firestore.rules
+++ b/config/firebase/firestore.rules
@@ -129,7 +129,7 @@ service cloud.firestore {
           'CodeVerifiedWithReportType14d-v1',
           'KeysUploadedWithReportType14d-v1',
           'SecondaryAttack14d-v1',
-          'PeriodicExposureNotification14d-v1'
+          'PeriodicExposureNotification14d-v1',
           'CodeVerifiedWithReportType14d-v2',
           'KeysUploadedWithReportType14d-v2',
           'SecondaryAttack14d-v2',

--- a/config/firebase/firestore.rules
+++ b/config/firebase/firestore.rules
@@ -126,6 +126,10 @@ service cloud.firestore {
           'KeysUploaded-v1',
           'DateExposure-v1',
           'KeysUploadedVaccineStatus-v1',
+          'CodeVerifiedWithReportType14d-v1',
+          'KeysUploadedWithReportType14d-v1',
+          'SecondaryAttack14d-v1',
+          'PeriodicExposureNotification14d-v1'
           'CodeVerifiedWithReportType14d-v2',
           'KeysUploadedWithReportType14d-v2',
           'SecondaryAttack14d-v2',

--- a/config/firebase/firestore.rules
+++ b/config/firebase/firestore.rules
@@ -126,10 +126,10 @@ service cloud.firestore {
           'KeysUploaded-v1',
           'DateExposure-v1',
           'KeysUploadedVaccineStatus-v1',
-          'CodeVerifiedWithReportType14d-v1',
-          'KeysUploadedWithReportType14d-v1',
-          'SecondaryAttack14d-v1',
-          'PeriodicExposureNotification14d-v1'
+          'CodeVerifiedWithReportType14d-v2',
+          'KeysUploadedWithReportType14d-v2',
+          'SecondaryAttack14d-v2',
+          'PeriodicExposureNotification14d-v2'
       ];
     }
 


### PR DESCRIPTION
Biweekly metrics are having their epsilon values changed from 10.2 to 8.
To avoid metrics with different epsilons ending in the same bucket, we decided to have metrics with an epsilon of 8 will appear as -v2.